### PR TITLE
Fix regression where output belt_to_ground entities are incorrectly placed backwards

### DIFF
--- a/scripts/reviver.lua
+++ b/scripts/reviver.lua
@@ -52,14 +52,14 @@ local function picker_revive_selected_ghosts(event)
                     if selected.ghost_type == 'underground-belt' then
                         local name = selected.ghost_name
                         local belt_type = selected.belt_to_ground_type
-                        player.build_from_cursor {position = position, direction = direction}
+                        if belt_type == 'output' then
+                            direction = (direction + 4) % 8
+                        end
 
+                        player.build_from_cursor {position = position, direction = direction}
                         local ent = player.surface.find_entity(name, position)
-                        if ent then
-                            if ent.belt_to_ground_type ~= belt_type then
-                                ent.rotate()
-                            end
-                            ent.direction = direction
+                        if belt_type == 'output' and ent then
+                            ent.rotate()
                         end
                     elseif selected.ghost_type == 'pipe-to-ground' then
                         local name = selected.ghost_name


### PR DESCRIPTION
### Summary
Fixes regression introduced in presumably 1.1 where belt_to_ground entities no longer respect direction updates.  

### Details
As of 1.1.36, belt_to_ground entities are always placed in the input direction, so we can plan accordingly to ensure that it faces the right way after rotation.  See https://forums.factorio.com/99074 for specific issue details.

### Testing
Verified manually in Sandbox scenario on 1.1.42.