### PR TITLE
Allow for picking of items whose name doesn't match the recipe's

### DIFF
--- a/scripts/crafter.lua
+++ b/scripts/crafter.lua
@@ -5,9 +5,18 @@ local Event = require('__stdlib__/stdlib/event/event')
 local lib = require('__PickerAtheneum__/utils/lib')
 
 local function santas_little_helper(player, name)
+    local crafted = false
     local allow_multiple = player.mod_settings['picker-allow-multiple-craft'].value
-    if game.recipe_prototypes[name] and player.force.recipes[name].enabled and (allow_multiple or player.get_item_count(name) == 0) then
-        player.begin_crafting { count = 1, recipe = name, silent = false }
+    for _, unlocked_recipe in pairs(player.force.recipes) do
+        for _, product in pairs(unlocked_recipe.products) do
+            if product.name == name then
+                local recipe_name = unlocked_recipe.name
+                if game.recipe_prototypes[recipe_name] and player.force.recipes[recipe_name].enabled and (allow_multiple or player.get_item_count(name) == 0) and crafted == false then
+                    player.begin_crafting { count = 1, recipe = recipe_name, silent = false }
+                    crafted = true
+                end
+            end
+        end
     end
 end
 

--- a/scripts/crafter.lua
+++ b/scripts/crafter.lua
@@ -5,15 +5,14 @@ local Event = require('__stdlib__/stdlib/event/event')
 local lib = require('__PickerAtheneum__/utils/lib')
 
 local function santas_little_helper(player, name)
-    local crafted = false
     local allow_multiple = player.mod_settings['picker-allow-multiple-craft'].value
     for _, unlocked_recipe in pairs(player.force.recipes) do
         for _, product in pairs(unlocked_recipe.products) do
             if product.name == name then
                 local recipe_name = unlocked_recipe.name
-                if game.recipe_prototypes[recipe_name] and player.force.recipes[recipe_name].enabled and (allow_multiple or player.get_item_count(name) == 0) and crafted == false then
+                if game.recipe_prototypes[recipe_name] and player.force.recipes[recipe_name].enabled and (allow_multiple or player.get_item_count(name) == 0) then
                     player.begin_crafting { count = 1, recipe = recipe_name, silent = false }
-                    crafted = true
+                    return
                 end
             end
         end


### PR DESCRIPTION
Previously, PickerExtended crafting would only work when the item that's being picked has the same name as the recipe that creates it. While this holds in some cases, it's not a foolproof solution.

This PR implements iterating through all unlocked recipes, to see if any of them create the picked item, and if so, queue the craft.